### PR TITLE
Change Option<> fields behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ options are simply overridden.
 
 ## TODOs / open questions
 
-1. Allow *not* overridding `Option<T> -> Option<T>` if the original `Option` is
-   set but not the applied one.
+1. Allow overridding `Option<T> -> Option<T>` if the original `Option` is
+   set but not the applied one?
 
 2. Allow wrapping behavior to be set without manually writing the struct name.
 

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -25,7 +25,7 @@ fn test_apply_options() {
     };
 
     let opt_config = OptionalConfig {
-        timeout: None,
+        timeout: Some(None),
         log_config: Some(OptionalLogConfig {
             log_file: Some("/tmp/bar.log".to_owned()),
             log_level: None,

--- a/tests/nested_skip.rs
+++ b/tests/nested_skip.rs
@@ -26,7 +26,7 @@ fn test_apply_options_nested_skip() {
     };
 
     let opt_config = OptionalConfig {
-        timeout: None,
+        timeout: Some(None),
         log_config: OptionalLogConfig {
             log_file: Some("/tmp/bar.log".to_owned()),
             log_level: None,

--- a/tests/renamed.rs
+++ b/tests/renamed.rs
@@ -23,7 +23,7 @@ fn test_apply_options() {
 
     opt_config.apply_to(&mut config);
 
-    assert_eq!(config.delay, None);
+    assert_eq!(config.delay, Some(2));
     assert_eq!(config.path, "/tmp/bar.log");
     assert_eq!(config.percentage, 42.24);
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -16,14 +16,14 @@ fn test_apply_options() {
     };
 
     let opt_config = OptionalConfig {
-        delay: None,
+        delay: Some(Some(5)),
         path: Some("/tmp/bar.log".to_owned()),
         percentage: Some(42.24),
     };
 
     opt_config.apply_to(&mut config);
 
-    assert_eq!(config.delay, None);
+    assert_eq!(config.delay, Some(5));
     assert_eq!(config.path, "/tmp/bar.log");
     assert_eq!(config.percentage, 42.24);
 }

--- a/tests/skip.rs
+++ b/tests/skip.rs
@@ -22,6 +22,6 @@ fn test_skip_wrapping() {
 
     opt_config.apply_to(&mut config);
 
-    assert_eq!(config.timeout, None);
+    assert_eq!(config.timeout, Some(2));
     assert!(!config.not_optional_at_all);
 }

--- a/tests/with_extra_derive.rs
+++ b/tests/with_extra_derive.rs
@@ -22,6 +22,6 @@ fn test_apply_options() {
 
     opt_config.apply_to(&mut config);
 
-    assert_eq!(config.delay, None);
+    assert_eq!(config.delay, Some(2));
     assert_eq!(config.path, "/tmp/bar.log");
 }


### PR DESCRIPTION
Currently there's a specialized behavior for Option<> fields - they are being overridden even if the applied field is none.

This is counter-intuitive, and doesn't make much sense (at least for me).

Remove the specialized behavior and make it behave similarly to any other field.

Note that this is a breaking change, so a further version bump is required.