### PR TITLE
Reintroduce applicable trait

### DIFF
--- a/implementation/src/lib.rs
+++ b/implementation/src/lib.rs
@@ -185,28 +185,18 @@ impl GenerateApplyFnVisitor {
         let new_name = &new.ident;
         let acc_concrete = self.acc_concrete;
         let acc_opt = self.acc_opt;
+        // TODO: everything was written with "t" as the parameter name, but this a. does not match
+        // the trait and b. is not explicit enough. Make this some parameter instead.
         quote! {
-            impl #impl_generics #new_name #ty_generics {
-                fn build(self, mut t: #orig_name #ty_generics) -> #orig_name #ty_generics {
-                    self.apply_to(&mut t);
-                    t
-                }
+            impl #impl_generics optional_struct::Applicable for #new_name #ty_generics {
+                type Base = #orig_name #ty_generics;
 
-                fn apply_to(self, t: &mut #orig_name #ty_generics) {
+                fn apply_to(self, t: &mut Self::Base) {
                     #acc_concrete
-                }
-
-                fn try_build(self) -> Result<#orig_name #ty_generics, Self> {
-                    self.try_into()
                 }
 
                 fn apply_to_opt(self, t: &mut Self) {
                     #acc_opt
-                }
-
-                fn apply(mut self, t: Self) -> Self {
-                    t.apply_to_opt(&mut self);
-                    self
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,21 @@
 #![no_std]
 pub use optional_struct_export::optional_struct;
+
+
+pub trait Applicable : Sized {
+    type Base;
+
+    fn build(self, mut base: Self::Base) -> Self::Base {
+        self.apply_to(&mut base);
+        base
+    }
+
+    fn apply_to(self, base: &mut Self::Base);
+
+    fn apply_to_opt(self, other: &mut Self);
+
+    fn apply(mut self, other: Self) -> Self {
+        other.apply_to_opt(&mut self);
+        self
+    }
+}

--- a/tests/applicable_generic.rs
+++ b/tests/applicable_generic.rs
@@ -1,0 +1,34 @@
+use optional_struct::*;
+
+fn generic_stuff_with_optional_struct<A: Applicable>(opt: A, base: A::Base) -> A::Base {
+    opt.build(base)
+}
+
+#[optional_struct]
+struct Config {
+    delay: Option<u32>,
+    path: String,
+    percentage: f32,
+}
+
+#[test]
+fn test_apply_options() {
+    let config = Config {
+        delay: Some(2),
+        path: "/var/log/foo.log".to_owned(),
+        percentage: 3.12,
+    };
+
+    let opt_config = OptionalConfig {
+        delay: None,
+        path: Some("/tmp/bar.log".to_owned()),
+        percentage: Some(42.24),
+    };
+
+    let config = generic_stuff_with_optional_struct(opt_config, config);
+
+    assert_eq!(config.delay, Some(2));
+    assert_eq!(config.path, "/tmp/bar.log");
+    assert_eq!(config.percentage, 42.24);
+}
+


### PR DESCRIPTION
Reintroduce the `Applyable` trait (this time named `Applicable`, because spelling is better than consistency).

This allows the structures generated by this crate to be used in generic context (again).

Fixes #22 