### PR TITLE
Make can_convert public

### DIFF
--- a/optional_struct_macro/src/opt_struct.rs
+++ b/optional_struct_macro/src/opt_struct.rs
@@ -50,7 +50,7 @@ impl GenerateCanConvertImpl {
 
         quote! {
             impl #impl_generics #new_name #ty_generics {
-                fn can_convert(&self) -> bool {
+                pub fn can_convert(&self) -> bool {
                     #acc
                     true
                 }


### PR DESCRIPTION
... so that you can make nested optional structs across different files.

(doing so leads to a compile error without this change)