### PR TITLE
add skip_struct option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ optional_struct_macro = { version = "0.5.2", path = "optional_struct_macro" }
 serde = { version = "1.0.193", features = ["derive"], default-features = false }
 
 [dev-dependencies]
+clap = { version = "4.5.16", features = ["derive", "std"] }
 serde = "1.0.193"
 serde_json = "1.0.108"

--- a/README.md
+++ b/README.md
@@ -189,6 +189,41 @@ struct will have the same field tagged `#[serde(skip_serializing_if = "Option::i
 This attribute makes serde skip fields entirely if the value of the `Option` is
 none (rather than saving e.g. `"value" = null` if serializing to json).
 
+7. Don't emit the optional struct definition.
+
+```rust
+use clap::Parser;
+use optional_struct::*;
+
+#[optional_struct(OptionalFoo, true, true)]
+pub struct Foo {
+    bar: char,
+    baz: bool,
+}
+
+#[derive(Parser, Debug, serde::Deserialize, serde::Serialize)]
+pub struct OptionalFoo {
+    #[clap(long)]
+    #[serde(default)]
+    pub bar: Option<char>,
+
+    #[clap(long)]
+    #[serde(default)]
+    pub baz: Option<bool>,
+}
+
+fn main() {
+    let opt_f = OptionalFoo::parse();
+    println!("{opt_f:?}");
+}
+```
+
+Normally `optional_struct` copies the derives and attributes from your original struct to the generated struct.   If you wish to specify different derives and/or attributes, the third parameter to the `optional_struct` macro tells `optional_struct` to skip emitting the struct definition so that it can be defined with different derives and/or attributes.   In this example, we use this capability to utilize [clap](https://docs.rs/clap/latest/clap/)'s derive macros.
+
+Even though the struct definition is not emitted, the impl for the struct is still emitted.   The following functions are still available:
+
+(See examples/clap.rs for a fuller example.)
+
 ## `apply`, `build`, and `try_build`
 
 Those three functions are used to build the final version of the structure, by

--- a/examples/clap.rs
+++ b/examples/clap.rs
@@ -1,0 +1,34 @@
+use clap::Parser;
+use optional_struct::*;
+
+#[optional_struct(OptionalFoo, true, true)]
+#[derive(Debug)]
+pub struct Foo {
+    bar: char,
+    baz: bool,
+}
+
+#[derive(Parser, Debug, serde::Deserialize, serde::Serialize)]
+pub struct OptionalFoo {
+    #[clap(long)]
+    #[serde(default)]
+    pub bar: Option<char>,
+
+    #[clap(long)]
+    #[serde(default)]
+    pub baz: Option<bool>,
+}
+
+fn main() {
+    let config_file = r#"{"bar":"a","baz":true}"#;
+    let config_args: OptionalFoo = serde_json::from_str(config_file).unwrap();
+    let cli_args = OptionalFoo::parse();
+    println!("config: {config_args:?} cli: {cli_args:?}");
+
+    // in conflict, cli_args wins
+    let merged = config_args.apply(cli_args);
+    println!("merged: {merged:?}");
+
+    let args: Foo = merged.try_into().unwrap();
+    println!("final {args:?}");
+}

--- a/optional_struct_macro/src/opt_struct.rs
+++ b/optional_struct_macro/src/opt_struct.rs
@@ -494,6 +494,7 @@ fn get_derive_macros(new: &DeriveInput, extra_derive: &[String]) -> TokenStream 
 struct ParsedMacroParameters {
     new_struct_name: Option<String>,
     default_wrapping: bool,
+    skip_struct: bool,
 }
 
 impl Parse for ParsedMacroParameters {
@@ -501,6 +502,7 @@ impl Parse for ParsedMacroParameters {
         let mut out = ParsedMacroParameters {
             new_struct_name: None,
             default_wrapping: true,
+            skip_struct: false,
         };
 
         if let Ok(struct_name) = Ident::parse(input) {
@@ -515,6 +517,16 @@ impl Parse for ParsedMacroParameters {
 
         if let Ok(wrapping) = syn::LitBool::parse(input) {
             out.default_wrapping = wrapping.value;
+        } else {
+            return Ok(out);
+        };
+
+        if input.parse::<Token![,]>().is_err() {
+            return Ok(out);
+        };
+
+        if let Ok(wrapping) = syn::LitBool::parse(input) {
+            out.skip_struct = wrapping.value;
         } else {
             return Ok(out);
         };
@@ -576,6 +588,7 @@ struct GlobalOptions {
     extra_derive: Vec<String>,
     default_wrapping_behavior: bool,
     make_fields_public: bool,
+    skip_struct: bool,
 }
 
 impl GlobalOptions {
@@ -584,6 +597,7 @@ impl GlobalOptions {
             .new_struct_name
             .unwrap_or_else(|| "Optional".to_owned() + &struct_definition.ident.to_string());
         let default_wrapping_behavior = attr.default_wrapping;
+        let skip_struct = attr.skip_struct;
         GlobalOptions {
             new_struct_name,
             extra_derive: vec!["Clone", "PartialEq", "Default", "Debug"]
@@ -592,6 +606,7 @@ impl GlobalOptions {
                 .collect(),
             default_wrapping_behavior,
             make_fields_public: true,
+            skip_struct,
         }
     }
 }
@@ -624,13 +639,20 @@ pub fn opt_struct(attr: TokenStream, input: TokenStream) -> OptionalStructOutput
     let try_from_impl = try_from_generator.get_implementation(&derive_input, &new);
     let applicable_impl = applicable_impl_generator.get_implementation(&derive_input, &new);
 
-    let derives = get_derive_macros(&new, &macro_params.extra_derive);
+    let generated = if macro_params.skip_struct {
+        quote! {
+            #applicable_impl
+            #try_from_impl
+        }
+    } else {
+        let derives = get_derive_macros(&new, &macro_params.extra_derive);
+        quote! {
+            #derives
+            #new
 
-    let generated = quote! {
-        #derives
-        #new
-        #applicable_impl
-        #try_from_impl
+            #applicable_impl
+            #try_from_impl
+        }
     };
 
     OptionalStructOutput {

--- a/optional_struct_macro/src/opt_struct.rs
+++ b/optional_struct_macro/src/opt_struct.rs
@@ -525,8 +525,8 @@ impl Parse for ParsedMacroParameters {
             return Ok(out);
         };
 
-        if let Ok(wrapping) = syn::LitBool::parse(input) {
-            out.skip_struct = wrapping.value;
+        if let Ok(skip_struct) = syn::LitBool::parse(input) {
+            out.skip_struct = skip_struct.value;
         } else {
             return Ok(out);
         };


### PR DESCRIPTION
I've been using optional_struct without using the macro for over a year because I couldn't get the macro to work properly with my usage of clap.   Your recent changes were useful but made redoing all the impl's even more painful.    So instead of redoing the impl's manually, update the macro so I only have to redo the struct.