### PR TITLE
add `optional_skip` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,24 @@ struct will have the same field tagged `#[serde(skip_serializing_if = "Option::i
 This attribute makes serde skip fields entirely if the value of the `Option` is
 none (rather than saving e.g. `"value" = null` if serializing to json).
 
+7. Skip a field entirely:
+
+```rust
+#[optional_struct]
+#[derive(Default)]
+struct Foo {
+    #[optional_skip]
+    bar: char,
+    baz: bool,
+}
+
+fn main() {
+    let opt_f = OptionalFoo { baz: Some(false) };
+}
+```
+
+If the `optional_skip` attribute is used, `Default` is used to fill in missing fields in the ``TryFrom` implementation.   Therefore Default must be implemented on the struct.
+
 ## `apply`, `build`, and `try_build`
 
 Those three functions are used to build the final version of the structure, by

--- a/optional_struct_macro/src/test.rs
+++ b/optional_struct_macro/src/test.rs
@@ -29,6 +29,19 @@ fn with_nested() {
 }
 
 #[test]
+fn with_skip() {
+    opt_struct(
+        quote!(),
+        quote!(
+            struct Foo {
+                #[optional_skip]
+                bar: Bar,
+            }
+        ),
+    );
+}
+
+#[test]
 fn with_serde_skip() {
     opt_struct(
         quote!(),


### PR DESCRIPTION
I've been using optional_struct without the macro for over a year.   With #30 I could theoretically use the macro instead, but in the intervening year I added a couple of attributes that don't belong in the OptionalStruct -- they're metadata rather than data, so I think this is a valid usage for me and likely for others.